### PR TITLE
add reconstruction by parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+_skbuild

--- a/flatdarkpv.py
+++ b/flatdarkpv.py
@@ -1,0 +1,65 @@
+import pvaccess as pva
+import numpy as np
+import time
+
+
+def FlatDarkBroadcast():
+    ##### init pvs ######
+    # frame type
+    chStreamFrameType = pva.Channel('2bma:TomoScan:FrameType', pva.CA)
+    # total number of dark fields
+    chStreamNumDarkFields = pva.Channel('2bma:TomoScan:NumDarkFields', pva.CA)
+    # total number of flat fields
+    chStreamNumFlatFields = pva.Channel('2bma:TomoScan:NumFlatFields', pva.CA)
+
+    # pva type pv that contains projection and metadata (angle, flag: regular, flat or dark)
+    chData = pva.Channel('2bmbSP1:Pva1:Image')
+    pvData = chData.get('')
+    # pva type pv for reconstrucion
+    pvDict = pvData.getStructureDict()
+    pvFlatDark = pva.PvObject(pvDict)
+    # take dimensions
+    width = pvData['dimension'][0]['size']
+    height = pvData['dimension'][1]['size']
+    depth = chStreamNumFlatFields.get(
+        '')['value']+chStreamNumDarkFields.get('')['value']
+
+    pvFlatDark['dimension'] = [{'size': width, 'fullSize': width, 'binning': 1},
+                               {'size': height, 'fullSize': height, 'binning': 1},
+                               {'size': depth, 'fullSize': depth, 'binning': 1}]
+
+    ##### run server for reconstruction pv #####
+    serverFlatDark = pva.PvaServer('2bma:TomoScan:FlatDark', pvFlatDark)
+
+    ##### init buffers #######
+    FlatDarkBuffer = np.zeros([depth, width*height], dtype='uint8')
+
+    numFlatDark = 0
+
+    def addData(pv):
+        """ read data from the detector, 2 types: flat, dark"""
+
+        nonlocal numFlatDark
+
+        curId = pv['uniqueId']
+        frameTypeAll = chStreamFrameType.get('')['value']
+        frameType = frameTypeAll['choices'][frameTypeAll['index']]
+        if(frameType == 'FlatField' or frameType == 'DarkField'):
+            FlatDarkBuffer[numFlatDark] = pv['value'][0]['ubyteValue']
+            numFlatDark += 1
+            print('id:', curId, 'type', frameType, 'num', numFlatDark)
+
+    #### start monitoring projection data ####
+    chData.monitor(addData, '')
+
+    while(1):
+        if(numFlatDark == depth):  # flat and dark are collected
+            print('start broadcasting flat and dark fields')
+            numFlatDark = 0  # reset counter
+            pvFlatDark['value'] = ({'ubyteValue': FlatDarkBuffer.flatten()},)
+        # rate limit
+        time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    FlatDarkBroadcast()

--- a/src/cuda/kernels.cuh
+++ b/src/cuda/kernels.cuh
@@ -109,4 +109,5 @@ void __global__ sumparts(float *f, int ipart, int nparts, int n, int nz)
 		if(i==ipart) continue;
 		f[tx + ty * n + ipart * n * nz] += f[tx + ty * n + i * n * nz];
 	}
+	f[tx + ty * n + ipart * n * nz] /= nparts;
 }

--- a/src/cuda/kernels.cuh
+++ b/src/cuda/kernels.cuh
@@ -1,34 +1,36 @@
 #define PI 3.141592653589793238
 
 
-void __global__ applyfilter(float2 *f, float* w, int n, int ntheta, int nz)
+void __global__ applyfilter(float2 *f, float* w, int n, int nz, int ntheta)
 {
 	int tx = blockDim.x * blockIdx.x + threadIdx.x;
 	int ty = blockDim.y * blockIdx.y + threadIdx.y;
 	int tz = blockDim.z * blockIdx.z + threadIdx.z;
-	if (tx >= n / 2 + 1 || ty >= ntheta || tz >= nz)
+	if (tx >= n / 2 + 1 || ty >= nz || tz >= ntheta)
 		return;
-	int id0 = tx + ty * (n / 2 + 1) + tz * ntheta * (n / 2 + 1);
+	int id0 = tx + ty * (n / 2 + 1) + tz * (n / 2 + 1) * nz;
 	//add normalization constant for data
 	float c = (ntheta * sqrtf(PI / 2) * n);
 	f[id0].x *= w[tx]/c;
 	f[id0].y *= w[tx]/c;
 }
 
-void __global__ correction(float *g, unsigned char *gs, float *flat, float *dark, int n, int ntheta, int nz)
+void __global__ correction(float *g, unsigned char *gs, float *flat, float *dark, int n, int nz, int ntheta)
 {
 	int tx = blockDim.x * blockIdx.x + threadIdx.x;
 	int ty = blockDim.y * blockIdx.y + threadIdx.y;
 	int tz = blockDim.z * blockIdx.z + threadIdx.z;
-	if (tx >= n || ty >= ntheta || tz >= nz)
+	if (tx >= n || ty >= nz || tz >= ntheta)
 		return;
-	int id = tx + ty * n + tz * ntheta * n;
-	int idf = tx + tz * n;
+	int id = tx + ty * n + tz * n * nz;
+	int idf = tx + ty * n;
 	g[id] =  -__logf(((float)gs[id]-dark[idf])/(flat[idf]-dark[idf]+1e-6)+1e-6);
+	
+	//	g[id] =  -__logf(((float)flat[idf]-dark[idf])/(255-dark[idf]+1e-6)+1e-6);
 
 }
 
-void __global__ orthox(float *f, float *g, float *theta, float center, int ix, int n, int ntheta, int nz)
+void __global__ orthox(float *f, float *g, float *theta, float center, int ix, int n, int nz, int ntheta)
 {
 	int ty = blockDim.x * blockIdx.x + threadIdx.x;
 	int tz = blockDim.y * blockIdx.y + threadIdx.y;
@@ -51,7 +53,7 @@ void __global__ orthox(float *f, float *g, float *theta, float center, int ix, i
 	f[ty + tz * n] = f0;
 }
 
-void __global__ orthoy(float *f, float *g, float *theta, float center, int iy, int n, int ntheta, int nz)
+void __global__ orthoy(float *f, float *g, float *theta, float center, int iy, int n, int nz, int ntheta)
 {
 	int tx = blockDim.x * blockIdx.x + threadIdx.x;
 	int tz = blockDim.y * blockIdx.y + threadIdx.y;
@@ -75,7 +77,7 @@ void __global__ orthoy(float *f, float *g, float *theta, float center, int iy, i
 	f[tx + tz * n] = f0;
 }
 
-void __global__ orthoz(float *f, float *g, float *theta, float center, int iz, int n, int ntheta, int nz)
+void __global__ orthoz(float *f, float *g, float *theta, float center, int iz, int n, int nz, int ntheta)
 {
 	int tx = blockDim.x * blockIdx.x + threadIdx.x;
 	int ty = blockDim.y * blockIdx.y + threadIdx.y;
@@ -96,18 +98,4 @@ void __global__ orthoz(float *f, float *g, float *theta, float center, int iz, i
 			f0 += g[ind] + (g[ind+1] - g[ind]) * (sp - s0) / n; 
 	}
 	f[tx + ty * n] = f0;
-}
-
-void __global__ sumparts(float *f, int ipart, int nparts, int n, int nz)
-{
-	int tx = blockDim.x * blockIdx.x + threadIdx.x;
-	int ty = blockDim.y * blockIdx.y + threadIdx.y;
-	if (tx >= n || ty >= nz)
-		return;
-	for (int i=0;i<nparts;i++)
-	{
-		if(i==ipart) continue;
-		f[tx + ty * n + ipart * n * nz] += f[tx + ty * n + i * n * nz];
-	}
-	f[tx + ty * n + ipart * n * nz] /= nparts;
 }

--- a/src/cuda/radonortho.cu
+++ b/src/cuda/radonortho.cu
@@ -1,13 +1,13 @@
 #include "radonortho.cuh"
 #include "kernels.cuh"
 #include  <stdio.h>
-radonortho::radonortho(size_t ntheta, size_t n, size_t nz, size_t nparts)
- : ntheta(ntheta), n(n), nz(nz), nparts(nparts) 
+radonortho::radonortho(size_t ntheta, size_t n, size_t nz, size_t nthetapi)
+ : ntheta(ntheta), n(n), nz(nz), nthetapi(nthetapi) 
 {
 	// arrays allocation on GPU
-	cudaMalloc((void **)&fx, n * nz * nparts * sizeof(float));
-	cudaMalloc((void **)&fy, n * nz * nparts *sizeof(float));
-	cudaMalloc((void **)&fz, n * n * nparts *sizeof(float));
+	cudaMalloc((void **)&fx, n * nz * sizeof(float));
+	cudaMalloc((void **)&fy, n * nz *sizeof(float));
+	cudaMalloc((void **)&fz, n * n *sizeof(float));
 	cudaMalloc((void **)&g, n * ntheta * nz * sizeof(float));
 	cudaMalloc((void **)&gs, n * ntheta * nz * sizeof(unsigned char));	
 	cudaMalloc((void **)&flat, n * nz * sizeof(float));
@@ -17,9 +17,9 @@ radonortho::radonortho(size_t ntheta, size_t n, size_t nz, size_t nparts)
 	cudaMalloc((void **)&filter, (n / 2 + 1) * sizeof(float));	
 	cudaMalloc((void **)&theta, ntheta * sizeof(float));
 
-	cudaMemset(fx, 0, n * nz * nparts * sizeof(float));
-	cudaMemset(fy, 0, n * nz * nparts * sizeof(float));
-	cudaMemset(fz, 0, n * n * nparts * sizeof(float));
+	cudaMemset(fx, 0, n * nz * sizeof(float));
+	cudaMemset(fy, 0, n * nz * sizeof(float));
+	cudaMemset(fz, 0, n * n * sizeof(float));
 	
 	//fft plans for filtering
 	int ffts[] = {n};
@@ -29,19 +29,15 @@ radonortho::radonortho(size_t ntheta, size_t n, size_t nz, size_t nparts)
 	int onembed[] = {n / 2 + 1};
 	cufftPlanMany(&plan_forward, 1, ffts, inembed, 1, idist, onembed, 1, odist, CUFFT_R2C, ntheta * nz);
 	cufftPlanMany(&plan_inverse, 1, ffts, onembed, 1, odist, inembed, 1, idist, CUFFT_C2R, ntheta * nz);
-
-
-	//start part id
-	ipart = 0;
-
+	
 	//init thread blocks and block grids
 	BS3d.x = 32;
 	BS3d.y = 32;
 	BS3d.z = 1;
 
 	GS3d1.x = ceil(n / (float)BS3d.x);
-	GS3d1.y = ceil(ntheta / (float)BS3d.y);
-	GS3d1.z = ceil(nz / (float)BS3d.z);
+	GS3d1.y = ceil(nz / (float)BS3d.y);
+	GS3d1.z = ceil(ntheta / (float)BS3d.z);
 
 	GS3d2.x = ceil(n / (float)BS3d.x);
 	GS3d2.y = ceil(n / (float)BS3d.y);
@@ -80,37 +76,32 @@ void radonortho::free()
 
 void radonortho::rec(size_t fx_,size_t fy_,size_t fz_, size_t g_, size_t theta_, float center, int ix, int iy, int iz)
 {
-	// copy data and angles to GPU
-	cudaMemcpy(gs, (unsigned char *)g_, n * ntheta * nz * sizeof(unsigned char), cudaMemcpyDefault);	
-	cudaMemcpy(theta, (float *)theta_, ntheta * sizeof(float), cudaMemcpyDefault);
-	
-	// convert short to float, apply dark-flat field correction
-	correction<<<GS3d1, BS3d>>>(g, gs, flat, dark, n, ntheta, nz);	
+	for (int i=0;i<nthetapi/ntheta;i++)
+	{
+		// copy data and angles to GPU
+		cudaMemcpy(gs, &((unsigned char *)g_)[i*ntheta*nz*n], n * ntheta * nz * sizeof(unsigned char), cudaMemcpyDefault);	
+		cudaMemcpy(theta, (float *)theta_, ntheta * sizeof(float), cudaMemcpyDefault);
+		
+		// convert short to float, apply dark-flat field correction
+		correction<<<GS3d1, BS3d>>>(g, gs, flat, dark, n, nz, ntheta);	
 
-	// fft for filtering in the frequency domain
-	cufftExecR2C(plan_forward, (cufftReal *)g, (cufftComplex *)fg);
-	// fbp filtering
-	applyfilter<<<GS3d1, BS3d>>>(fg, filter, n, ntheta, nz);
-	// fft back
-	cufftExecC2R(plan_inverse, (cufftComplex *)fg, (cufftReal *)g);
-	
-	// reconstruct slices via summation over lines	
-	orthox<<<GS3d3, BS3d>>>(&fx[ipart * n * nz], g, theta, center, ix, n, ntheta, nz);
-	orthoy<<<GS3d3, BS3d>>>(&fy[ipart * n * nz], g, theta, center, iy, n, ntheta, nz);	
-	orthoz<<<GS3d2, BS3d>>>(&fz[ipart * n * n], g, theta, center, iz, n, ntheta, nz);
-	
-	// next part to be rewriten
-	ipart = (ipart+1)%nparts;
-
-	// sum parts for the result, put the result into the part to be changed on the next iteration
-	sumparts<<<GS3d3, BS3d>>>(fx, ipart, nparts, n, nz);
-	sumparts<<<GS3d3, BS3d>>>(fy, ipart, nparts, n, nz);
-	sumparts<<<GS3d2, BS3d>>>(fz, ipart, nparts, n, n);
-	
+		// fft for filtering in the frequency domain
+		cufftExecR2C(plan_forward, (cufftReal *)g, (cufftComplex *)fg);
+		// fbp filtering
+		applyfilter<<<GS3d1, BS3d>>>(fg, filter, n, nz, ntheta);
+		// fft back
+		cufftExecC2R(plan_inverse, (cufftComplex *)fg, (cufftReal *)g);
+		
+		// reconstruct slices via summation over lines	
+		orthox<<<GS3d3, BS3d>>>(fx, g, theta, center, ix, n, nz, ntheta);
+		orthoy<<<GS3d3, BS3d>>>(fy, g, theta, center, iy, n, nz, ntheta);
+		orthoz<<<GS3d2, BS3d>>>(fz, g, theta, center, iz, n, nz, ntheta);
+	}			
+		
 	//copy result to cpu
-	cudaMemcpy((float *)fx_, &fx[ipart * n * nz], n * nz * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy((float *)fy_, &fy[ipart * n * nz], n * nz * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy((float *)fz_, &fz[ipart * n * n], n * n * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy((float *)fx_, fx, n * nz * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy((float *)fy_, fy, n * nz * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy((float *)fz_, fz, n * n * sizeof(float), cudaMemcpyDefault);	
 }
 
 void radonortho::set_filter(size_t filter_)

--- a/src/cuda/radonortho.i
+++ b/src/cuda/radonortho.i
@@ -13,9 +13,10 @@ public:
   size_t n;
   size_t ntheta;
   size_t nz;
+  size_t nparts;
 
   %mutable;
-  radonortho(size_t ntheta, size_t n, size_t nz);
+  radonortho(size_t ntheta, size_t n, size_t nz, size_t nparts);
   ~radonortho();
   void rec(size_t fx, size_t fy, size_t fz, size_t g, size_t theta, float center, int ix, int iy, int iz);  
   void set_filter(size_t filter);  

--- a/src/cuda/radonortho.i
+++ b/src/cuda/radonortho.i
@@ -13,10 +13,10 @@ public:
   size_t n;
   size_t ntheta;
   size_t nz;
-  size_t nparts;
+  size_t nthetapi;
 
   %mutable;
-  radonortho(size_t ntheta, size_t n, size_t nz, size_t nparts);
+  radonortho(size_t ntheta, size_t n, size_t nz, size_t nthetapi);
   ~radonortho();
   void rec(size_t fx, size_t fy, size_t fz, size_t g, size_t theta, float center, int ix, int iy, int iz);  
   void set_filter(size_t filter);  

--- a/src/include/radonortho.cuh
+++ b/src/include/radonortho.cuh
@@ -16,8 +16,10 @@ class radonortho
 	
 	float2 *fg;
 	float *theta;
-	float *filter; 
+	float *filter; 	
 
+	size_t ipart;
+	
 	cufftHandle plan_forward;
 	cufftHandle plan_inverse;
 
@@ -30,7 +32,8 @@ public:
 	size_t n;
 	size_t ntheta;
 	size_t nz;
-	radonortho(size_t ntheta, size_t n, size_t nz);
+	size_t nparts;
+	radonortho(size_t ntheta, size_t n, size_t nz, size_t nparts);
 	~radonortho();
 	void rec(size_t fx, size_t fy, size_t fz, size_t g, size_t theta, float center, int ix, int iy, int iz);
 	void set_filter(size_t filter);

--- a/src/include/radonortho.cuh
+++ b/src/include/radonortho.cuh
@@ -18,8 +18,6 @@ class radonortho
 	float *theta;
 	float *filter; 	
 
-	size_t ipart;
-	
 	cufftHandle plan_forward;
 	cufftHandle plan_inverse;
 
@@ -32,8 +30,8 @@ public:
 	size_t n;
 	size_t ntheta;
 	size_t nz;
-	size_t nparts;
-	radonortho(size_t ntheta, size_t n, size_t nz, size_t nparts);
+	size_t nthetapi;
+	radonortho(size_t ntheta, size_t n, size_t nz, size_t nthetapi);
 	~radonortho();
 	void rec(size_t fx, size_t fy, size_t fz, size_t g, size_t theta, float center, int ix, int iy, int iz);
 	void set_filter(size_t filter);

--- a/src/orthorec/solver.py
+++ b/src/orthorec/solver.py
@@ -11,19 +11,23 @@ def getp(a):
 
 
 class OrthoRec(radonortho):
-    """Class for tomography reconstruction of orthogonal slices thorugh direct 
+    """Class for tomography reconstruction of orthogonal slices through direct 
     discreatization of line integrals in the Radon transform.
     Attribtues
     ----------
     ntheta : int
-        The number of projections.    
+        The number of projections in the buffer (for simultaneous reconstruction)
     n, nz : int
         The pixel width and height of the projection.
+    nthetapi: int
+        The total number of angles to cover the interval [0,pi]
     """
 
-    def __init__(self, ntheta, n, nz):
+    def __init__(self, ntheta, n, nz, nthetapi):
         """Create class for the tomo solver."""
-        super().__init__(ntheta, n, nz)
+        # total number of parts for final summation 
+        nparts = nthetapi//ntheta
+        super().__init__(ntheta, n, nz, nparts)
         self.init_filter('parzen')
         
         def signal_handler(sig, frame):  # Free gpu memory after SIGINT, SIGSTSTP

--- a/src/orthorec/solver.py
+++ b/src/orthorec/solver.py
@@ -25,9 +25,8 @@ class OrthoRec(radonortho):
 
     def __init__(self, ntheta, n, nz, nthetapi):
         """Create class for the tomo solver."""
-        # total number of parts for final summation 
-        nparts = int(nthetapi//ntheta)
-        super().__init__(ntheta, n, nz, nparts)
+        # total number of parts for final summation         
+        super().__init__(ntheta, n, nz, nthetapi)
         self._initFilter('parzen')
         
         def signal_handler(sig, frame):  # Free gpu memory after SIGINT, SIGSTSTP

--- a/src/orthorec/solver.py
+++ b/src/orthorec/solver.py
@@ -26,9 +26,9 @@ class OrthoRec(radonortho):
     def __init__(self, ntheta, n, nz, nthetapi):
         """Create class for the tomo solver."""
         # total number of parts for final summation 
-        nparts = nthetapi//ntheta
+        nparts = int(nthetapi//ntheta)
         super().__init__(ntheta, n, nz, nparts)
-        self.init_filter('parzen')
+        self._initFilter('parzen')
         
         def signal_handler(sig, frame):  # Free gpu memory after SIGINT, SIGSTSTP
             print('free GPU')
@@ -47,17 +47,17 @@ class OrthoRec(radonortho):
         """Free GPU memory due at interruptions or with-block exit."""
         self.free()
 
-    def set_flat(self, flat):
+    def setFlat(self, flat):
         """Copy flat field to GPU for flat field correction"""
         flat = np.ascontiguousarray(flat.astype('float32'))
         super().set_flat(getp(flat))
 
-    def set_dark(self, dark):
+    def setDark(self, dark):
         """Copy dark field to GPU for dark field correction"""
         dark = np.ascontiguousarray(dark.astype('float32'))
         super().set_dark(getp(dark))
 
-    def rec_ortho(self, data, theta, center, ix, iy, iz):
+    def recOrtho(self, data, theta, center, ix, iy, iz):
         """Reconstruction of 3 ortho slices with respect to ix,iy,iz indeces"""
         recx = np.zeros([self.nz, self.n], dtype='float32')
         recy = np.zeros([self.nz, self.n], dtype='float32')
@@ -71,7 +71,7 @@ class OrthoRec(radonortho):
 
         return recx, recy, recz
 
-    def init_filter(self, filter='parzen', p=2):
+    def _initFilter(self, filter='parzen', p=2):
         """Instead of direct integral discretization in the frequency domain by using the rectangular rule, 
         i.e. \int_a^b |signa| h(\sigma) d\sigma = \sum_k |\sigma_k| h(\sigma_k), 
         use a higher order polynomials for approximation \int_a^b |sigma| h(\sigma) d\sigma = \sum_k w_k h(\sigma_k), where 

--- a/streaming_rec.py
+++ b/streaming_rec.py
@@ -1,17 +1,14 @@
 import pvaccess as pva
-import numpy as np
 from orthorec import *
-
+import numpy as np
 import time
 from timing import tic, toc
-from rwlock import RWLock
 
-# global r/w lock variable for r/w from the projection buffer
-#mrwlock = RWLock()
 
 def readByChoice(ch):
     allch = ch.get('')['value']
     return allch['choices'][allch['index']]
+
 
 def streaming():
     """
@@ -20,7 +17,7 @@ def streaming():
     """
 
     ##### init pvs ######
-    
+
     # frame type
     chStreamFrameType = pva.Channel('2bma:TomoScan:FrameType', pva.CA)
     # theta array
@@ -31,11 +28,7 @@ def streaming():
     chStreamNumDarkFields = pva.Channel('2bma:TomoScan:NumDarkFields', pva.CA)
     # total number of flat fields
     chStreamNumFlatFields = pva.Channel('2bma:TomoScan:NumFlatFields', pva.CA)
-    # dark field mode
-    chStreamDarkFieldMode = pva.Channel('2bma:TomoScan:DarkFieldMode', pva.CA)
-    # flat field mode
-    chStreamFlatFieldMode = pva.Channel('2bma:TomoScan:FlatFieldMode', pva.CA)
-    
+
     # GUI PVs
     # streaming status
     chStreamStatus = pva.Channel('2bma:TomoScan:StreamStatus', pva.CA)
@@ -44,20 +37,22 @@ def streaming():
     # binning for projection data
     chStreamBinning = pva.Channel('2bma:TomoScan:StreamBinning', pva.CA)
     # ring removal
-    chStreamRingRemoval = pva.Channel('2bma:TomoScan:StreamRingRemoval', pva.CA)
+    chStreamRingRemoval = pva.Channel(
+        '2bma:TomoScan:StreamRingRemoval', pva.CA)
     # Paganin filtering
     chStreamPaganin = pva.Channel('2bma:TomoScan:StreamPaganin', pva.CA)
     # parameter alpha for Paganin filtering
-    chStreamPaganinAlpha = pva.Channel('2bma:TomoScan:StreamPaganinAlpha', pva.CA)
+    chStreamPaganinAlpha = pva.Channel(
+        '2bma:TomoScan:StreamPaganinAlpha', pva.CA)
     # rotation center
     chStreamCenter = pva.Channel('2bma:TomoScan:StreamCenter', pva.CA)
-    # filter type for reconstrution 
-    chStreamFilterType = pva.Channel('2bma:TomoScan:StreamFilterType', pva.CA)    
+    # filter type for reconstrution
+    chStreamFilterType = pva.Channel('2bma:TomoScan:StreamFilterType', pva.CA)
     # orthoslices
     chStreamOrthoX = pva.Channel('2bma:TomoScan:StreamOrthoX', pva.CA)
     chStreamOrthoY = pva.Channel('2bma:TomoScan:StreamOrthoY', pva.CA)
     chStreamOrthoZ = pva.Channel('2bma:TomoScan:StreamOrthoZ', pva.CA)
-    
+
     # Try to read:
     print('######TEST: READ PVS FROM GUI#######')
     print('status', readByChoice(chStreamStatus))
@@ -71,10 +66,14 @@ def streaming():
     print('idx', chStreamOrthoX.get('')['value'])
     print('idy', chStreamOrthoY.get('')['value'])
     print('idz', chStreamOrthoZ.get('')['value'])
-    
+
     # pva type pv that contains projection and metadata (angle, flag: regular, flat or dark)
     chData = pva.Channel('2bmbSP1:Pva1:Image')
-    pvData = chData.get('')    
+    pvData = chData.get('')
+    # pva type flat and dark fields pv broadcasted from the detector machine
+    chFlatDark = pva.Channel('2bma:TomoScan:FlatDark')
+    pvFlatDark = chFlatDark.get('')
+
     # pva type pv for reconstrucion
     pvDict = pvData.getStructureDict()
     pvRec = pva.PvObject(pvDict)
@@ -84,7 +83,7 @@ def streaming():
     # set dimensions for reconstruction (assume width>=height)
     pvRec['dimension'] = [{'size': 3*width, 'fullSize': 3*width, 'binning': 1},
                           {'size': height, 'fullSize': height, 'binning': 1}]
-    
+
     ##### run server for reconstruction pv #####
     serverRec = pva.PvaServer('2bma:TomoScan:StreamReconstruction', pvRec)
 
@@ -92,51 +91,61 @@ def streaming():
     # form circular buffer, whenever the angle goes higher than 180
     # than corresponding projection is replacing the first one
     bufferSize = chStreamBufferSize.get('')['value']
-    bufferSizeFlat = chStreamNumFlatFields.get('')['value']
-    bufferSizeDark = chStreamNumDarkFields.get('')['value']
+    # number of dark and flat fields
+    numFlat = chStreamNumFlatFields.get('')['value']
+    numDark = chStreamNumDarkFields.get('')['value']
 
     projBuffer = np.zeros([bufferSize, width*height], dtype='uint8')
-    flatBuffer = np.zeros([bufferSizeFlat, width*height], dtype='uint8')
-    darkBuffer = np.zeros([bufferSizeDark, width*height], dtype='uint8')
+    flatBuffer = np.ones([numFlat, width*height], dtype='uint8')
+    darkBuffer = np.zeros([numDark, width*height], dtype='uint8')
     thetaBuffer = np.zeros(bufferSize, dtype='float32')
 
-	# load angles
+    # load angles
     theta = chStreamThetaArray.get(
         '')['value'][:chStreamNumAngles.get('')['value']]
     # number of angles in the interval of size pi (to be used for 1 streaming reconstuction)
     # at some point we can also use >1 rotations for 1 reconstruction, todo later
-    numThetaPi = np.where(theta-theta[0]>180)[0][0]
-    print('angles in the interval of the size pi: ', numThetaPi)
-    
-    # number of acquired flat, dark fields, and projections
-    numFlat = 0
-    numDark = 0
+    numThetaPi = int(np.where(theta-theta[0] > 180)[0][0])
+    print('number of angles in the interval of the size pi: ', numThetaPi)
+
+    # number of acquired projections
     numProj = 0
 
     def addData(pv):
         """ read data from the detector, 3 types: flat, dark, projection"""
-        nonlocal numFlat
-        nonlocal numDark
+
+        if(readByChoice(chStreamStatus) == 'Off'):
+            return
+
         nonlocal numProj
 
-        # with mrwlock.w_locked():
         curId = pv['uniqueId']
         frameTypeAll = chStreamFrameType.get('')['value']
         frameType = frameTypeAll['choices'][frameTypeAll['index']]
-        if(frameType == 'FlatField'):
-            flatBuffer[numFlat] = pv['value'][0]['ubyteValue']
-            numFlat += 1
-        if(frameType == 'DarkField'):
-            darkBuffer[numDark] = pv['value'][0]['ubyteValue']
-            numDark += 1
         if(frameType == 'Projection'):
-            projBuffer[np.mod(numProj, bufferSize)] = pv['value'][0]['ubyteValue']
+            projBuffer[np.mod(numProj, bufferSize)
+                       ] = pv['value'][0]['ubyteValue']
             thetaBuffer[np.mod(numProj, bufferSize)] = theta[curId-1]
             numProj += 1
-        print('id:', curId, 'type', frameType)
-        
+            #print('id:', curId, 'type', frameType)
+
+    flgFlatDark = False  # flat and dark exist or not
+
+    def addFlatDark(pv):
+        """ read flat and dark fields from the manually running pv server on the detector machine"""
+        nonlocal flgFlatDark
+        if(pv['value'][0]):
+            flatBuffer[:] = pv['value'][0]['ubyteValue'][numDark *
+                                                         width*height:].reshape(numFlat, width*height)
+            darkBuffer[:] = pv['value'][0]['ubyteValue'][:numDark *
+                                                         width*height].reshape(numFlat, width*height)
+            flgFlatDark = True
+            print('new flat and dark fields acquired')
+
     #### start monitoring projection data ####
     chData.monitor(addData, '')
+    #### start monitoring dark and flat fields pv ####
+    chFlatDark.monitor(addFlatDark, '')
 
     # create solver class on GPU
     slv = OrthoRec(bufferSize, width, height, numThetaPi)
@@ -144,42 +153,42 @@ def streaming():
     recAll = np.zeros([width, 3*width], dtype='float32')
 
     # wait until dark and flats are acquired
-    while(numProj == 0):
+    while(flgFlatDark == False):
         1
-    if(numFlat==0 or numDark==0):
-        print('no dark/flat field data. EXIT')
-        exit()
 
     # init data as flat to avoid problems of taking -log of zeros
     projBuffer[:] = flatBuffer[0]
-    # copy dark and flat to GPU
-    slv.setFlat(np.mean(flatBuffer[:numFlat], axis=0))
-    slv.setDark(np.mean(darkBuffer[:numDark], axis=0))
+
+    # copy mean dark and flat to GPU
+    slv.setFlat(np.mean(flatBuffer, axis=0))
+    slv.setDark(np.mean(darkBuffer, axis=0))
 
     ##### streaming reconstruction ######
-    while(readByChoice(chStreamStatus)=='On'):
+    while(1):
+        if(readByChoice(chStreamStatus) == 'Off'):
+            continue
         # with mrwlock.r_locked():  # lock buffer before reading
         projPart = projBuffer.copy()
         thetaPart = thetaBuffer.copy()
 
-        ### take parameters from the GUI ###        
-        binning = readByChoice(chStreamBinning)# to implement in cuda
-        ringRemoval = readByChoice(chStreamRingRemoval)# to implement in cuda
-        Paganin = readByChoice(chStreamRingPaganin)# to implement in cuda
-        PaganinAlpha = chStreamPaganinAlpha.get('')['value']# to implement in cuda
+        ### take parameters from the GUI ###
+        binning = readByChoice(chStreamBinning)  # todo
+        ringRemoval = readByChoice(chStreamRingRemoval)  # todo
+        Paganin = readByChoice(chStreamPaganin)  # todo
+        PaganinAlpha = chStreamPaganinAlpha.get('')['value']  # todo
         center = chStreamCenter.get('')['value']
-        filterType = readByChoice(chStreamFilterType)# to implement in cuda
-        
+        filterType = readByChoice(chStreamFilterType)  # todo
+
         # 3 ortho slices ids
         idX = chStreamOrthoX.get('')['value']
         idY = chStreamOrthoY.get('')['value']
         idZ = chStreamOrthoZ.get('')['value']
-        
+
         # reconstruct on GPU
-        # tic()
+        tic()
         recX, recY, recZ = slv.recOrtho(
             projPart, thetaPart*np.pi/180, center, idX, idY, idZ)
-        #print('rec time:',toc(),'norm',np.linalg.norm(recx))
+        print('rec time:', toc())
 
         # concatenate (supposing nz<n)
         recAll[:height, :width] = recX
@@ -189,7 +198,6 @@ def streaming():
         pvRec['value'] = ({'floatValue': recAll.flatten()},)
         # reconstruction rate limit
         time.sleep(0.1)
-
 
 if __name__ == "__main__":
     streaming()

--- a/streaming_rec.py
+++ b/streaming_rec.py
@@ -48,7 +48,7 @@ def streaming():
     # NEW: PV channel that contains projection and metadata (angle, flag: regular, flat or dark)
     chdata = pva.Channel('2bmbSP1:Pva1:Image')
     pvdata = chdata.get('')
-# init pva streaming pv for reconstrucion with coping dictionary from pvdata
+    # init pva streaming pv for reconstrucion with coping dictionary from pvdata
     pvdict = pvdata.getStructureDict()
     pvrec = pva.PvObject(pvdict)
 
@@ -77,24 +77,13 @@ def streaming():
     thetabuffer = np.zeros(ntheta, dtype='float32')
 
 
-	# Load angles
+	# load angles
     theta = chStreamThetaArray.get(
         '')['value'][:chStreamNumAngles.get('')['value']]
-
-    # the following is not needed, since the id is set to zero before acquiring pojections    
-    # find first id of the projection data, skipping ids for dark and flat fields
-    # flatmodeall = chStreamFlatFieldMode.get('')['value']
-    # flatmode = flatmodeall['choices'][flatmodeall['index']]
-    # darkmodeall = chStreamDarkFieldMode.get('')['value']
-    # darkmode = darkmodeall['choices'][darkmodeall['index']]
-
-    # firstid = chdata.get('')['uniqueId']
-    # if(flatmode == 'Start' or flatmode=='Both'):
-    # 	firstid += chStreamNumFlatFields.get('')['value']
-    # if(darkmode == 'Start' or darkmode=='Both'):
-    # 	firstid += chStreamNumDarkFields.get('')['value']
-    # print('first projection id', firstid)
-
+    # number of angles in the interval of size pi
+    nthetapi = np.where(theta-theta[0]>np.pi)
+    print('angles in the interval of the size pi: ', nthetapi)
+    
     nflat = 0
     ndark = 0
     nproj = 0
@@ -126,7 +115,7 @@ def streaming():
     chdata.monitor(addData, '')
 
     # create solver class on GPU
-    slv = OrthoRec(ntheta, n, nz)
+    slv = OrthoRec(ntheta, n, nz, nthetapi)
     # allocate memory for result slices
     recall = np.zeros([n, 3*n], dtype='float32')
 

--- a/streaming_rec.py
+++ b/streaming_rec.py
@@ -127,7 +127,7 @@ def streaming():
             flatBuffer[numFlat] = pv['value'][0]['ubyteValue']
             numFlat += 1
         if(frameType == 'DarkField'):
-            darkBuffer[ndark] = pv['value'][0]['ubyteValue']
+            darkBuffer[numDark] = pv['value'][0]['ubyteValue']
             numDark += 1
         if(frameType == 'Projection'):
             projBuffer[np.mod(numProj, bufferSize)] = pv['value'][0]['ubyteValue']


### PR DESCRIPTION
<!--Thank you for opening a pull request!

We appreciate that you care about this project enough to fix it, and we welcome contributions. We will make every effort to review your pull request in a timely manner. Please help us by following the instructions below.
-->

## Purpose
Allow reconstruction by parts in order to decrease CPU-GPU data transfers and the amount of computations

## Approach
<!--Describe how your changes address the problem.

Provide a brief summary of your algorithm(s) here.
-->
Instead of reconstructing from a big number of projections, the idea is to split the whole interval of the size pi by parts of the buffer sizes and get partial reconstruction from each part, then sum these parts to get the final reconstruction. Whenever the new part appears it is stored in a circular array. 
Example: number of angles in the interval [0,pi], nthetapi=720. Buffer size ntheta=120. Then a circular array contains 6 reconstruction elements [0..5] for each orthoslice, final reconstruction is a sum of these 6. Whenever the 7th element appears it replaces the first one and the final reconstruction is updated, and so on.
