### PR TITLE
Optimize reconstruction engine

### DIFF
--- a/tomostream/kernels.py
+++ b/tomostream/kernels.py
@@ -2,11 +2,10 @@ import cupy as cp
 
 source = """
 extern "C" {    
-    void __global__ orthox(float *f, float *g, float *theta, float center, int ix, int n, int nz, int ntheta)
+    void __global__ orthox(float *f, float *g, float *theta, float* center, int* ix, int n, int nz, int ntheta)
     {
         int ty = blockDim.x * blockIdx.x + threadIdx.x;
         int tz = blockDim.y * blockIdx.y + threadIdx.y;
-        int tx = ix;
         if (ty >= n || tz >= nz)
             return;
         float sp = 0;
@@ -15,7 +14,7 @@ extern "C" {
         int ind = 0;
         for (int k = 0; k < ntheta; k++)
         {
-            sp = (tx - n / 2) * __cosf(theta[k]) - (ty - n / 2) * __sinf(theta[k]) + center; //polar coordinate
+            sp = (ix[k] - n / 2) * __cosf(theta[k]) - (ty - n / 2) * __sinf(theta[k]) + center[k]; //polar coordinate
             //linear interpolation
             s0 = roundf(sp);
             ind = k * n * nz + tz * n + s0;
@@ -25,11 +24,10 @@ extern "C" {
         f[ty + tz * n] = f0;
     }
 
-    void __global__ orthoy(float *f, float *g, float *theta, float center, int iy, int n, int nz, int ntheta)
+    void __global__ orthoy(float *f, float *g, float *theta, float* center, int* iy, int n, int nz, int ntheta)
     {
         int tx = blockDim.x * blockIdx.x + threadIdx.x;
         int tz = blockDim.y * blockIdx.y + threadIdx.y;
-        int ty = iy;
         if (tx >= n  || tz >= nz)
             return;
         float sp = 0;
@@ -38,7 +36,7 @@ extern "C" {
         int ind = 0;
         for (int k = 0; k < ntheta; k++)
         {
-            sp = (tx - n / 2) * __cosf(theta[k]) - (ty - n / 2) * __sinf(theta[k]) + center; //polar coordinate
+            sp = (tx - n / 2) * __cosf(theta[k]) - (iy[k] - n / 2) * __sinf(theta[k]) + center[k]; //polar coordinate
             //linear interpolation
             s0 = roundf(sp);
             ind = k * n * nz + tz * n + s0;
@@ -48,11 +46,10 @@ extern "C" {
         f[tx + tz * n] = f0;
     }
 
-    void __global__ orthoz(float *f, float *g, float *theta, float center, int iz, int n, int nz, int ntheta)
+    void __global__ orthoz(float *f, float *g, float *theta, float* center, int* iz, int n, int nz, int ntheta)
     {
         int tx = blockDim.x * blockIdx.x + threadIdx.x;
         int ty = blockDim.y * blockIdx.y + threadIdx.y;
-        int tz = iz;
         if (tx >= n || ty >= n)
             return;
         float sp = 0;
@@ -61,15 +58,15 @@ extern "C" {
         int ind = 0;
         for (int k = 0; k < ntheta; k++)
         {
-            sp = (tx - n / 2) * __cosf(theta[k]) - (ty - n / 2) * __sinf(theta[k]) + center; //polar coordinate
+            sp = (tx - n / 2) * __cosf(theta[k]) - (ty - n / 2) * __sinf(theta[k]) + center[k]; //polar coordinate
             //linear interpolation
-            if(sp<0) sp=0;
-            if(sp>=n-2) sp=n-2;
+            //if(sp<0) sp=0;
+            //if(sp>=n-2) sp=n-2;
             s0 = roundf(sp);
 
-            ind = k * n * nz + tz * n + s0;
-            //if ((s0 >= 0) & (s0 < n - 1))            
-            f0 += g[ind] + (g[ind+1] - g[ind]) * (sp - s0) / n; 
+            ind = k * n * nz + iz[k] * n + s0;
+            if ((s0 >= 0) & (s0 < n - 1))            
+                f0 += g[ind] + (g[ind+1] - g[ind]) * (sp - s0) / n; 
         }
         f[tx + ty * n] = f0;
     }
@@ -85,7 +82,6 @@ orthoz_kernel = module.get_function('orthoz')
 def orthox(data, theta, center, ix):
     [ntheta, nz, n] = data.shape
     objx = cp.zeros([nz, n], dtype='float32')
-    theta=theta.astype('float32')    
     orthox_kernel((int(n/32+0.5), int(nz/32+0.5)), (32, 32),
                   (objx, data, theta, center, ix, n, nz, ntheta))
     return objx

--- a/tomostream/recon.py
+++ b/tomostream/recon.py
@@ -44,11 +44,12 @@ class Recon():
         # form circular buffer, whenever the angle goes higher than 180
         # than corresponding projection is replacing the first one
         # number of dark and flat fields
-        buffer_size = ts_pvs['chStreamBufferSize'].get('')['value']
+        buffer_size = 360#ts_pvs['chStreamBufferSize'].get('')['value']
         
-        print(self.datatype)
         self.proj_buffer = np.zeros([buffer_size, width*height], dtype=self.datatype)
         self.theta_buffer = np.zeros(buffer_size, dtype='float32')
+        self.ids_buffer = np.zeros(buffer_size, dtype='int32')
+        
         # load angles
         self.theta = ts_pvs['chStreamThetaArray'].get(
             '')['value'][:ts_pvs['chStreamNumAngles'].get('')['value']]
@@ -69,16 +70,21 @@ class Recon():
         
 
     def add_data(self, pv):
-        """ read data from the detector, 3 types: flat, dark, projection"""
+        """ add projection data and corresponding angle to a circular buffer"""
         if(self.ts_pvs['chStreamStatus'].get('')['value']['index']==1):            
             cur_id = pv['uniqueId']
             frame_type_all = self.ts_pvs['chStreamFrameType'].get('')['value']
             frame_type = frame_type_all['choices'][frame_type_all['index']]
             if(frame_type == 'Projection'):
+                # write projection to a buffer
                 self.proj_buffer[np.mod(self.num_proj, self.buffer_size)
                                 ] = pv['value'][0][type_dict[self.datatype]]
+                # write theta to a buffer                
                 self.theta_buffer[np.mod(
                     self.num_proj, self.buffer_size)] = self.theta[cur_id]
+                # write position in the projection buffer                                
+                self.ids_buffer[np.mod(
+                    self.num_proj, self.buffer_size)] = np.mod(self.num_proj, self.buffer_size)                
                 self.num_proj += 1
                 log.info('id: %s type %s', cur_id, frame_type)
 
@@ -94,28 +100,38 @@ class Recon():
             dark = dark.reshape(num_dark_fields, self.height, self.width)
             flat = flat.reshape(num_flat_fields, self.height, self.width)
             
-            self.slv.setDark(dark)
-            self.slv.setFlat(flat)
+            self.slv.set_dark(dark)
+            self.slv.set_flat(flat)
             log.info('new flat and dark fields acquired')
 
     def run(self):        
         ##### streaming reconstruction ######
+        id_start = 0
         while(True):
             if(self.ts_pvs['chStreamStatus'].get('')['value']['index']==1):
-                proj_part = self.proj_buffer.copy()
-                theta_part = self.theta_buffer.copy()
+                # take positions of new projections in the buffer
+                ids = np.mod(np.arange(id_start,self.num_proj),self.buffer_size)
+                id_start = self.num_proj
 
+                if(len(ids)==0): # if no new data in the buffer then continue
+                    continue                
+                if(len(ids)>self.buffer_size): # if the buffer was overfilled, take it all
+                    ids = np.arange(self.buffer_size)
+                
+                # make copies of what should be processed                
+                proj_part = self.proj_buffer[ids].copy()
+                theta_part = self.theta_buffer[ids].copy()
+                ids_part = self.ids_buffer[ids].copy()
+                
                 ### take parameters from the GUI ###
                 center = np.float32(self.ts_pvs['chStreamCenter'].get('')['value'])
-
-                # 3 ortho slices ids
                 idX = self.ts_pvs['chStreamOrthoX'].get('')['value']
                 idY = self.ts_pvs['chStreamOrthoY'].get('')['value']
                 idZ = self.ts_pvs['chStreamOrthoZ'].get('')['value']
-
+                log.info('center %s: idx, idy,idz: %s %s %s',center,idX,idY,idZ)
                 # reconstruct on GPU
                 util.tic()
-                rec = self.slv.recon(proj_part, theta_part, center, idX, idY, idZ)
+                rec = self.slv.recon_optimized(proj_part, theta_part, ids_part, center, idX, idY, idZ)
                 log.info('rec time: %s', util.toc())
 
                 # write to pv


### PR DESCRIPTION
The object from the whole set of projections in the interval of size pi is reconstructed by replacing the reconstruction part corresponding to incoming projections only, i.e. objpi=objpi+recon(data)-recon(dataold). This trick significantly (~10x) accelerates the whole reconstruction scheme.